### PR TITLE
Minor simplification for GetDetailsUseCase

### DIFF
--- a/flask_profiler/use_cases/get_details_use_case.py
+++ b/flask_profiler/use_cases/get_details_use_case.py
@@ -40,7 +40,7 @@ class GetDetailsUseCase:
         results = self.archivist.get_records()
         if request.method_filter is not None:
             results = results.with_method(request.method_filter)
-        if request.name_filter is not None:
+        if request.name_filter:
             results = results.with_name_containing(request.name_filter)
         if request.requested_after is not None:
             results = results.requested_after(request.requested_after)


### PR DESCRIPTION
Before this change we would filter by the request name when retrieving data even when the name filter string is the empty string. After this commit we won't filter anymore when the filter string is empty.